### PR TITLE
Jmacglashan

### DIFF
--- a/src/burlap/domain/singleagent/blocksworld/BlocksWorld.java
+++ b/src/burlap/domain/singleagent/blocksworld/BlocksWorld.java
@@ -4,12 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import burlap.oomdp.auxiliary.DomainGenerator;
-import burlap.oomdp.core.Attribute;
-import burlap.oomdp.core.Domain;
-import burlap.oomdp.core.ObjectClass;
-import burlap.oomdp.core.ObjectInstance;
-import burlap.oomdp.core.PropositionalFunction;
-import burlap.oomdp.core.State;
+import burlap.oomdp.core.*;
 import burlap.oomdp.singleagent.Action;
 import burlap.oomdp.singleagent.SADomain;
 import burlap.oomdp.singleagent.explorer.TerminalExplorer;
@@ -268,6 +263,11 @@ public class BlocksWorld implements DomainGenerator {
 			
 			return st;
 		}
+
+		@Override
+		public List<TransitionProbability> getTransitions(State s, String [] params){
+			return this.deterministicTransition(s, params);
+		}
 		
 		
 	}
@@ -317,6 +317,11 @@ public class BlocksWorld implements DomainGenerator {
 			}
 			
 			return st;
+		}
+
+		@Override
+		public List<TransitionProbability> getTransitions(State s, String [] params){
+			return this.deterministicTransition(s, params);
 		}
 		
 	}

--- a/src/burlap/domain/singleagent/cartpole/CartPoleDomain.java
+++ b/src/burlap/domain/singleagent/cartpole/CartPoleDomain.java
@@ -1,17 +1,14 @@
 package burlap.domain.singleagent.cartpole;
 
 import burlap.oomdp.auxiliary.DomainGenerator;
-import burlap.oomdp.core.Attribute;
-import burlap.oomdp.core.Domain;
-import burlap.oomdp.core.ObjectClass;
-import burlap.oomdp.core.ObjectInstance;
-import burlap.oomdp.core.State;
-import burlap.oomdp.core.TerminalFunction;
+import burlap.oomdp.core.*;
 import burlap.oomdp.singleagent.Action;
 import burlap.oomdp.singleagent.GroundedAction;
 import burlap.oomdp.singleagent.RewardFunction;
 import burlap.oomdp.singleagent.SADomain;
 import burlap.oomdp.singleagent.explorer.VisualExplorer;
+
+import java.util.List;
 
 
 /**
@@ -585,7 +582,12 @@ public class CartPoleDomain implements DomainGenerator {
 			}
 			return CartPoleDomain.this.moveClassicModel(s, this.dir);
 		}
-		
+
+
+		@Override
+		public List<TransitionProbability> getTransitions(State s, String [] params){
+			return this.deterministicTransition(s, params);
+		}
 		
 		
 	}

--- a/src/burlap/domain/singleagent/lunarlander/LunarLanderDomain.java
+++ b/src/burlap/domain/singleagent/lunarlander/LunarLanderDomain.java
@@ -4,12 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import burlap.oomdp.auxiliary.DomainGenerator;
-import burlap.oomdp.core.Attribute;
-import burlap.oomdp.core.Domain;
-import burlap.oomdp.core.ObjectClass;
-import burlap.oomdp.core.ObjectInstance;
-import burlap.oomdp.core.PropositionalFunction;
-import burlap.oomdp.core.State;
+import burlap.oomdp.core.*;
 import burlap.oomdp.singleagent.Action;
 import burlap.oomdp.singleagent.SADomain;
 import burlap.oomdp.singleagent.explorer.TerminalExplorer;
@@ -894,6 +889,11 @@ public class LunarLanderDomain implements DomainGenerator {
 			return st;
 		}
 
+		@Override
+		public List<TransitionProbability> getTransitions(State s, String [] params){
+			return this.deterministicTransition(s, params);
+		}
+
 		
 	}
 	
@@ -921,6 +921,11 @@ public class LunarLanderDomain implements DomainGenerator {
 		protected State performActionHelper(State st, String[] params) {
 			updateMotion(st, 0.0);
 			return st;
+		}
+
+		@Override
+		public List<TransitionProbability> getTransitions(State s, String [] params){
+			return this.deterministicTransition(s, params);
 		}
 		
 		
@@ -955,6 +960,11 @@ public class LunarLanderDomain implements DomainGenerator {
 		protected State performActionHelper(State st, String[] params) {
 			updateMotion(st, thrustValue);
 			return st;
+		}
+
+		@Override
+		public List<TransitionProbability> getTransitions(State s, String [] params){
+			return this.deterministicTransition(s, params);
 		}
 		
 		

--- a/src/burlap/domain/singleagent/mountaincar/MountainCar.java
+++ b/src/burlap/domain/singleagent/mountaincar/MountainCar.java
@@ -1,16 +1,13 @@
 package burlap.domain.singleagent.mountaincar;
 
 import burlap.oomdp.auxiliary.DomainGenerator;
-import burlap.oomdp.core.Attribute;
-import burlap.oomdp.core.Domain;
-import burlap.oomdp.core.ObjectClass;
-import burlap.oomdp.core.ObjectInstance;
-import burlap.oomdp.core.State;
-import burlap.oomdp.core.TerminalFunction;
+import burlap.oomdp.core.*;
 import burlap.oomdp.singleagent.Action;
 import burlap.oomdp.singleagent.SADomain;
 import burlap.oomdp.singleagent.explorer.VisualExplorer;
 import burlap.oomdp.visualizer.Visualizer;
+
+import java.util.List;
 
 
 /**
@@ -244,6 +241,11 @@ public class MountainCar implements DomainGenerator {
 		@Override
 		protected State performActionHelper(State s, String[] params) {
 			return MountainCar.this.move(s, dir);
+		}
+
+		@Override
+		public List<TransitionProbability> getTransitions(State s, String [] params){
+			return this.deterministicTransition(s, params);
 		}
 		
 	}

--- a/src/burlap/oomdp/core/Domain.java
+++ b/src/burlap/oomdp/core/Domain.java
@@ -120,7 +120,7 @@ public abstract class Domain {
 		if(!attributeMap.containsKey(att.name)){
 			attributes.add(att);
 			attributeMap.put(att.name, att);
-			if(att.type == Attribute.AttributeType.REAL || att.type == Attribute.AttributeType.MULTITARGETRELATIONAL){
+			if(att.type == Attribute.AttributeType.RELATIONAL || att.type == Attribute.AttributeType.MULTITARGETRELATIONAL){
 				if(!this.objectIdentifierDependentDomain) {
 					DPrint.cl(this.debugCode, "Relational attribute added to domain; forcing domain flag to object identifier dependent.");
 					this.objectIdentifierDependentDomain = true;

--- a/src/burlap/oomdp/singleagent/Action.java
+++ b/src/burlap/oomdp/singleagent/Action.java
@@ -9,13 +9,15 @@ import burlap.oomdp.core.TransitionProbability;
 
 
 /**
- * Abstract class for defining what happens when an action is executed in a state. The method getTransitions(State s, String [] params)
- * is what defines the transition dynamics of the MDP for this action. If this method is not overridden by subclasses, then the default
- * behavior is to assume deterministic transition dynamics which are produced by sampling the performAction(State s, String [] params)
- * method and setting its returned state as having a transition probability of 1. If the domain being created is only
+ * Abstract class for defining what happens when an action is executed in a state. The method {@link #getTransitions(burlap.oomdp.core.State, String[])}
+ * is what defines the transition dynamics of the MDP for this action. If this method is not overridden by subclasses, then an
+ * UnsupportedOperation exception is thrown . If the domain being created is only
  * going to be used planning/learning algorithms that require a generative model, rather than the fully enumerated transition
- * dynamics, then the getTransitions(State s, String [] params) does not need to be defined, but for full robustness it should be.
- * 
+ * dynamics, then the {@link #getTransitions(burlap.oomdp.core.State, String[])} does not need to be implemented, but for full robustness it should be.
+ * If your domain is deterministic, you can trivially implement it by having it return a call to the {@link #deterministicTransition(burlap.oomdp.core.State, String[])}
+ * method, which will wrap the result of a {@link #performAction(burlap.oomdp.core.State, String[])}} method with a 1.0 outcome probability
+ * {@link burlap.oomdp.core.TransitionProbability} object and insert it in a list containing just that element.
+ * <p/>
  * Action objects may also be defined to require object parameters (which must adhere to a type). Parameters can also have parameter order groups specified if
  * there is effect symmetry when changing the order of the parameters. That is, if you swapped the parameter assignments for parameters in the same order group, the action would have
  * the same effect. However, if you swapped the parameter assignments of two parameters in different order groups, the action would have a different effect. 
@@ -289,23 +291,36 @@ public abstract class Action {
 	/**
 	 * Returns the transition probabilities for applying this action in the given state with the given set of parameters.
 	 * Transition probabilities are specified as list of {@link burlap.oomdp.core.TransitionProbability} objects. The list
-	 * is only required to contain transitions with non-zero probability. By default, this method assumes that transition
-	 * dynamics are deterministic and it returns a list with a single TransitionProbability with probability 1 whose
-	 * state is determined by querying the {@link #performAction(State, String [])} method. If the transition dynamics
-	 * are stochastic, then this method needs to be overridden.
+	 * is only required to contain transitions with non-zero probability. Since not all planning algorithms require
+	 * the full transition dynamics (and since it's impossible to enumerate them in some infinite state space domains),
+	 * this method is not requried to be implemented. However, it will throw an UnsupportedOperationException
+	 * if it is not overriden by the Action subclass if it is called by an algorithm that requires it.
 	 * @param s the state from which the transition probabilities when applying this action will be returned.
 	 * @param params a String array specifying the action object parameters
 	 * @return a List of transition probabilities for applying this action in the given state with the given set of parameters
 	 */
 	public List<TransitionProbability> getTransitions(State s, String [] params){
-		
+		throw new UnsupportedOperationException("The full transition dynamics for action " + this.getName() + "  were" +
+				"request, but have not be defined in the implemented Action class. Please override the " +
+				"getTransitions(State String[] params) method for this action.");
+	}
+
+
+	/**
+	 * Returns the transition dynamics by assuming the action to be deterministic and wrapping the result of a
+	 * {@link #performAction(burlap.oomdp.core.State, String[])} method with a 1.0 probable {@link TransitionProbability}
+	 * object and inserting it in the returned list.
+	 * @param s the state from which the transition probabilities when applying this action will be returned.
+	 * @param params a String array specifying the action object parameters
+	 * @return a List of one element of type {@link burlap.oomdp.core.TransitionProbability} whose state is the outcome of the {@link #performAction(burlap.oomdp.core.State, String[])} method.
+	 */
+	protected List<TransitionProbability> deterministicTransition(State s, String [] params){
 		List <TransitionProbability> transition = new ArrayList<TransitionProbability>();
 		State res = this.performAction(s, params);
 		transition.add(new TransitionProbability(res, 1.0));
-		
+
 		return transition;
 	}
-	
 	
 	
 	/**


### PR DESCRIPTION
_If you have made your own domains, see the commit notes!_ Deterministic domains now need to implement the getTransitions method if they are to be used by algorithms like DP that make requests to that method. Otherwise, an exception will be thrown by default if the method is not implemented.
