### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/burlap/behavior/singleagent/auxiliary/StateReachability.java
+++ b/src/burlap/behavior/singleagent/auxiliary/StateReachability.java
@@ -30,6 +30,10 @@ public class StateReachability {
 	 */
 	public static int			debugID = 837493;
 	
+	private StateReachability() {
+	    // do nothing
+	}
+	
 	
 	/**
 	 * Returns the list of {@link burlap.oomdp.core.states.State} objects that are reachable from a source state.

--- a/src/burlap/behavior/singleagent/learnfromdemo/apprenticeship/ApprenticeshipLearning.java
+++ b/src/burlap/behavior/singleagent/learnfromdemo/apprenticeship/ApprenticeshipLearning.java
@@ -54,6 +54,10 @@ public class ApprenticeshipLearning {
 	
 	public static final int								debugCodeScore = 746329;
 	public static final int								debugCodeRFWeights = 636392;
+	
+	private ApprenticeshipLearning() {
+	    // do nothing
+	}
 
 	/**
 	 * Calculates the Feature Expectations given one demonstration, a feature mapping and a discount factor gamma

--- a/src/burlap/behavior/singleagent/learnfromdemo/mlirl/support/BoltzmannPolicyGradient.java
+++ b/src/burlap/behavior/singleagent/learnfromdemo/mlirl/support/BoltzmannPolicyGradient.java
@@ -18,6 +18,9 @@ import java.util.Set;
  */
 public class BoltzmannPolicyGradient {
 
+    private BoltzmannPolicyGradient() {
+        // do nothing
+    }
 
 	/**
 	 * Computes the gradient of a Boltzmann policy using the given differentiable valueFunction.

--- a/src/burlap/behavior/singleagent/planning/deterministic/MultiStatePrePlanner.java
+++ b/src/burlap/behavior/singleagent/planning/deterministic/MultiStatePrePlanner.java
@@ -17,6 +17,10 @@ import burlap.oomdp.core.states.State;
  */
 public class MultiStatePrePlanner {
 
+    private MultiStatePrePlanner() {
+        // do nothing
+    }
+    
 	/**
 	 * Runs a planning algorithm from multiple initial states to ensure that an adequate plan/policy exist for of the states.
 	 * @param planner the valueFunction to be used.

--- a/src/burlap/behavior/stochasticgames/solvers/CorrelatedEquilibriumSolver.java
+++ b/src/burlap/behavior/stochasticgames/solvers/CorrelatedEquilibriumSolver.java
@@ -39,6 +39,10 @@ import com.joptimizer.optimizers.LPPrimalDualMethod;
  */
 public class CorrelatedEquilibriumSolver {
 
+    private CorrelatedEquilibriumSolver() {
+        // do nothing
+    }
+    
 	/**
 	 * The four different equilibrium objectives that can be used:
 	 * UTILITARIAN, EGALITARIAN, REPUBLICAN, and LIBERTARIAN.

--- a/src/burlap/behavior/stochasticgames/solvers/GeneralBimatrixSolverTools.java
+++ b/src/burlap/behavior/stochasticgames/solvers/GeneralBimatrixSolverTools.java
@@ -7,6 +7,10 @@ package burlap.behavior.stochasticgames.solvers;
  *
  */
 public class GeneralBimatrixSolverTools {
+    
+    private GeneralBimatrixSolverTools() {
+        // do nothing
+    }
 	
 	
 	/**

--- a/src/burlap/behavior/stochasticgames/solvers/MinMaxSolver.java
+++ b/src/burlap/behavior/stochasticgames/solvers/MinMaxSolver.java
@@ -6,6 +6,10 @@ import scpsolver.lpsolver.SolverFactory;
 import scpsolver.problems.LinearProgram;
 
 public class MinMaxSolver {
+    
+    private MinMaxSolver() {
+        // do nothing
+    }
 
 	
 	

--- a/src/burlap/behavior/valuefunction/QFunction.java
+++ b/src/burlap/behavior/valuefunction/QFunction.java
@@ -35,6 +35,10 @@ public interface QFunction extends ValueFunction{
 	 * methods for computing the value function of a state, given the Q-values (the max Q-value or policy weighted value).
 	 */
 	public static class QFunctionHelper {
+	    
+	    private QFunctionHelper() {
+	        // do nothing
+	    }
 
 		/**
 		 * Returns the optimal state value function for a state given a {@link QFunction}.

--- a/src/burlap/datastructures/WekaInterfaces.java
+++ b/src/burlap/datastructures/WekaInterfaces.java
@@ -14,7 +14,10 @@ import weka.core.Instances;
  * @author James MacGlashan.
  */
 public class WekaInterfaces {
-
+    
+    private WekaInterfaces() {
+        // do nothing
+    }
 
 	/**
 	 * Creates a Weka {@link Instance} for a state by first converting the state into a feature vector and then creating

--- a/src/burlap/debugtools/DPrint.java
+++ b/src/burlap/debugtools/DPrint.java
@@ -22,6 +22,9 @@ public class DPrint {
 	 */
 	static boolean					universalPrint = true;
 	
+	private DPrint() {
+	    // do nothing
+	}
 	
 	/**
 	 * Specify whether previously unset debug codes will by default be allowed to print or not.

--- a/src/burlap/debugtools/DebugFlags.java
+++ b/src/burlap/debugtools/DebugFlags.java
@@ -16,6 +16,10 @@ public class DebugFlags {
 	 */
 	private static Map <Integer, Integer> flags;
 	
+	private DebugFlags() {
+	    // do nothing
+	}
+	
 	/**
 	 * Creates/sets a debug flag
 	 * @param id the flag identifier

--- a/src/burlap/domain/singleagent/blockdude/BlockDudeLevelConstructor.java
+++ b/src/burlap/domain/singleagent/blockdude/BlockDudeLevelConstructor.java
@@ -11,6 +11,9 @@ import burlap.oomdp.core.states.State;
  */
 public class BlockDudeLevelConstructor {
 
+    private BlockDudeLevelConstructor() {
+        // do nothing
+    }
 
 	/**
 	 * Returns the initial {@link burlap.oomdp.core.states.State} of the first level.

--- a/src/burlap/domain/singleagent/blockdude/BlockDudeVisualizer.java
+++ b/src/burlap/domain/singleagent/blockdude/BlockDudeVisualizer.java
@@ -16,6 +16,9 @@ import java.awt.geom.Rectangle2D;
  */
 public class BlockDudeVisualizer {
 
+    private BlockDudeVisualizer() {
+        // do nothing
+    }
 
 	/**
 	 * Returns a {@link burlap.oomdp.visualizer.Visualizer} for {@link burlap.domain.singleagent.blockdude.BlockDude}.

--- a/src/burlap/domain/singleagent/blocksworld/BlocksWorldVisualizer.java
+++ b/src/burlap/domain/singleagent/blocksworld/BlocksWorldVisualizer.java
@@ -15,6 +15,10 @@ import burlap.oomdp.visualizer.Visualizer;
 
 public class BlocksWorldVisualizer {
 
+    private BlocksWorldVisualizer() {
+        // do nothing
+    }
+    
 	
 	/**
 	 * Returns a 2D Visualizer canvas object to visualize {@link BlocksWorld} states.

--- a/src/burlap/domain/singleagent/cartpole/CartPoleVisualizer.java
+++ b/src/burlap/domain/singleagent/cartpole/CartPoleVisualizer.java
@@ -21,6 +21,10 @@ import burlap.oomdp.visualizer.Visualizer;
  */
 public class CartPoleVisualizer {
 
+    private CartPoleVisualizer() {
+        // do nothing
+    }
+    
 	/**
 	 * Returns a visualizer for cart pole.
 	 * @return a visualizer for cart pole.

--- a/src/burlap/domain/singleagent/cartpole/InvertedPendulumVisualizer.java
+++ b/src/burlap/domain/singleagent/cartpole/InvertedPendulumVisualizer.java
@@ -14,6 +14,10 @@ import burlap.oomdp.visualizer.Visualizer;
 
 public class InvertedPendulumVisualizer {
 
+    private InvertedPendulumVisualizer() {
+        
+    }
+    
 	
 	/**
 	 * Returns a {@link Visualizer} object for the {@link InvertedPendulum} domain.

--- a/src/burlap/domain/singleagent/frostbite/FrostbiteVisualizer.java
+++ b/src/burlap/domain/singleagent/frostbite/FrostbiteVisualizer.java
@@ -19,6 +19,10 @@ public class FrostbiteVisualizer {
 	private final static Color waterColor = new Color(0.34509805f, 0.43529412f, 0.60784316f);
 	static int glob = 0;
 
+	private FrostbiteVisualizer() {
+	    // do nothing
+	}
+	
 	/**
 	 * Returns a visualizer for a lunar lander domain.
 	 *

--- a/src/burlap/domain/singleagent/gridworld/GridWorldVisualizer.java
+++ b/src/burlap/domain/singleagent/gridworld/GridWorldVisualizer.java
@@ -25,6 +25,10 @@ import burlap.oomdp.visualizer.Visualizer;
  *
  */
 public class GridWorldVisualizer {
+    
+    private GridWorldVisualizer() {
+        // do nothing
+    }
 
 	
 	/**

--- a/src/burlap/domain/singleagent/lunarlander/LLVisualizer.java
+++ b/src/burlap/domain/singleagent/lunarlander/LLVisualizer.java
@@ -22,6 +22,9 @@ import burlap.oomdp.visualizer.Visualizer;
  */
 public class LLVisualizer {
 
+    private LLVisualizer() {
+        // do nothing
+    }
 
 	/**
 	 * Returns a {@link burlap.oomdp.visualizer.Visualizer} for a {@link burlap.domain.singleagent.lunarlander.LunarLanderDomain} using

--- a/src/burlap/domain/singleagent/mountaincar/MountainCarVisualizer.java
+++ b/src/burlap/domain/singleagent/mountaincar/MountainCarVisualizer.java
@@ -21,6 +21,10 @@ import burlap.oomdp.visualizer.Visualizer;
  * The agent will be drawn as a red square and the shape of the hill in a black line.
  */
 public class MountainCarVisualizer {
+    
+    private MountainCarVisualizer() {
+        // do nothing
+    }
 
 	
 	/**

--- a/src/burlap/domain/stochasticgames/gridgame/GGVisualizer.java
+++ b/src/burlap/domain/stochasticgames/gridgame/GGVisualizer.java
@@ -25,6 +25,10 @@ import burlap.oomdp.visualizer.Visualizer;
  *
  */
 public class GGVisualizer {
+    
+    private GGVisualizer() {
+        // do nothing
+    }
 
 	
 	/**

--- a/src/burlap/oomdp/core/AbstractObjectParameterizedGroundedAction.java
+++ b/src/burlap/oomdp/core/AbstractObjectParameterizedGroundedAction.java
@@ -43,6 +43,10 @@ public interface AbstractObjectParameterizedGroundedAction extends AbstractGroun
 
 
 	public static class Helper {
+	    
+	    private Helper() {
+	        // do nothing
+	    }
 
 		/**
 		 * This method will translate this object's parameters that were assigned for a given source state, into object parameters in the

--- a/src/burlap/oomdp/singleagent/FullActionModel.java
+++ b/src/burlap/oomdp/singleagent/FullActionModel.java
@@ -43,6 +43,10 @@ public interface FullActionModel {
 	 * A class with helper methods for working with actions that implement {@link burlap.oomdp.singleagent.FullActionModel}.
 	 */
 	public static class FullActionModelHelper{
+	    
+	    private FullActionModelHelper() {
+	        // do nothing
+	    }
 
 
 		/**

--- a/src/burlap/oomdp/singleagent/environment/EnvironmentDelegation.java
+++ b/src/burlap/oomdp/singleagent/environment/EnvironmentDelegation.java
@@ -24,6 +24,10 @@ public interface EnvironmentDelegation extends Environment {
 	 * A class that provides tools for working with Environment delegates
 	 */
 	public static class EnvDelegationTools{
+	    
+	    private EnvDelegationTools() {
+	        // do nothing
+	    }
 
 		/**
 		 * Returns the root {@link burlap.oomdp.singleagent.environment.Environment} delegate. Useful

--- a/src/burlap/tutorials/scd/ContinuousDomainTutorial.java
+++ b/src/burlap/tutorials/scd/ContinuousDomainTutorial.java
@@ -44,6 +44,10 @@ import java.util.List;
 
 
 public class ContinuousDomainTutorial {
+    
+    private ContinuousDomainTutorial() {
+        // do nothing
+    }
 
 	public static void MCLSPIFB(){
 


### PR DESCRIPTION

This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed…ors.