### PR TITLE
Code quality fix -  "public static" fields should be constant

### DIFF
--- a/src/burlap/behavior/singleagent/auxiliary/StateReachability.java
+++ b/src/burlap/behavior/singleagent/auxiliary/StateReachability.java
@@ -28,7 +28,7 @@ public class StateReachability {
 	/**
 	 * The debugID used for making calls to {@link burlap.debugtools.DPrint}.
 	 */
-	public static int			debugID = 837493;
+	public static final int			debugID = 837493;
 	
 	
 	/**

--- a/src/burlap/behavior/stochasticgames/agents/naiveq/history/SGQWActionHistory.java
+++ b/src/burlap/behavior/stochasticgames/agents/naiveq/history/SGQWActionHistory.java
@@ -81,7 +81,7 @@ public class SGQWActionHistory extends SGNaiveQLAgent {
 	/**
 	 * A constant for the name of the history object class. 
 	 */
-	public static String						CLASSHISTORY = "histAID";
+	public static final String						CLASSHISTORY = "histAID";
 	
 	
 	

--- a/src/burlap/behavior/stochasticgames/agents/twoplayer/singlestage/equilibriumplayer/BimatrixEquilibriumSolver.java
+++ b/src/burlap/behavior/stochasticgames/agents/twoplayer/singlestage/equilibriumplayer/BimatrixEquilibriumSolver.java
@@ -23,7 +23,7 @@ public abstract class BimatrixEquilibriumSolver {
 	/**
 	 * The epislon difference used to test for double equality.
 	 */
-	public static double doubleEpislon = 1e-8;
+	public static final double doubleEpislon = 1e-8;
 	
 	
 	/**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 - "public static" fields should be constant
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Faisal Hameed