### PR TITLE
Code quality fix - "equals(Object obj)" and "hashCode()" should be overridden in pairs.

### DIFF
--- a/src/burlap/behavior/singleagent/planning/stochastic/montecarlo/uct/UCTStateNode.java
+++ b/src/burlap/behavior/singleagent/planning/stochastic/montecarlo/uct/UCTStateNode.java
@@ -69,17 +69,30 @@ public class UCTStateNode {
 	
 	
 	@Override
-	public boolean equals(Object o){
-		
-		if(!(o instanceof UCTStateNode)){
-			return false;
-		}
-		
-		UCTStateNode os = (UCTStateNode)o;
-		
-		return state.equals(os.state) && depth == os.depth;
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((actionNodes == null) ? 0 : actionNodes.hashCode());
+        result = prime * result + depth;
+        result = prime * result + n;
+        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        return result;
+    }
+	
+	
+	@Override
+    public boolean equals(Object o){
+        
+        if(!(o instanceof UCTStateNode)){
+            return false;
+        }
+        
+        UCTStateNode os = (UCTStateNode)o;
+        
+        return state.equals(os.state) && depth == os.depth;
+        
+    }
 	
 	
 	

--- a/src/burlap/domain/stochasticgames/gridgame/GridGameStandardMechanics.java
+++ b/src/burlap/domain/stochasticgames/gridgame/GridGameStandardMechanics.java
@@ -922,17 +922,32 @@ public class GridGameStandardMechanics extends JointActionModel {
 		}
 		
 		
+		
 		@Override
-		public boolean equals(Object o){
-			if(!(o instanceof Location2)){
-				return false;
-			}
-			
-			Location2 ol = (Location2)o;
-			
-			return x == ol.x && y == ol.y;
-			
-		}
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getOuterType().hashCode();
+            result = prime * result + x;
+            result = prime * result + y;
+            return result;
+        }
+
+		@Override
+        public boolean equals(Object o){
+            if(!(o instanceof Location2)){
+                return false;
+            }
+            
+            Location2 ol = (Location2)o;
+            
+            return x == ol.x && y == ol.y;
+            
+        }
+
+        private GridGameStandardMechanics getOuterType() {
+            return GridGameStandardMechanics.this;
+        }
 		
 	}
 	

--- a/src/burlap/oomdp/core/GroundedProp.java
+++ b/src/burlap/oomdp/core/GroundedProp.java
@@ -1,6 +1,8 @@
 package burlap.oomdp.core;
 
 
+import java.util.Arrays;
+
 import burlap.oomdp.core.states.State;
 
 /**
@@ -62,50 +64,61 @@ public class GroundedProp implements Cloneable{
 	}
 	
 	
+	
+	@Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(params);
+        result = prime * result + ((pf == null) ? 0 : pf.hashCode());
+        return result;
+    }
+
+
 	public boolean equals(Object obj){
-		if(this == obj){
-			return true;
-		}
-		
-		if(!(obj instanceof GroundedProp)){
-			return false;
-		}
-		
-		GroundedProp that = (GroundedProp)obj;
-		
-		if(pf != that.pf){
-			return false;
-		}
-		
-		if(params.length != that.params.length){
-			return false;
-		}
-		
-		for(int i = 0; i < params.length; i++){
-			if(!params[i].equals(that.params[i])){
-				//check if there is another parameter with this reference that has the same rename class (which means parameters are order independent)
-				String orderGroup = pf.parameterOrderGroup[i];
-				boolean foundMatch = false;
-				for(int j = 0; j < that.params.length; j++){
-					if(j == i){
-						continue; //already checked this
-					}
-					if(orderGroup.equals(that.pf.parameterOrderGroup[j])){
-						if(params[i].equals(that.params[j])){
-							foundMatch = true;
-							break;
-						}
-					}
-					
-				}
-				if(!foundMatch){
-					return false;
-				}
-			}
-		}
-		
-		return true;
-		
-	}
+        if(this == obj){
+            return true;
+        }
+        
+        if(!(obj instanceof GroundedProp)){
+            return false;
+        }
+        
+        GroundedProp that = (GroundedProp)obj;
+        
+        if(pf != that.pf){
+            return false;
+        }
+        
+        if(params.length != that.params.length){
+            return false;
+        }
+        
+        for(int i = 0; i < params.length; i++){
+            if(!params[i].equals(that.params[i])){
+                //check if there is another parameter with this reference that has the same rename class (which means parameters are order independent)
+                String orderGroup = pf.parameterOrderGroup[i];
+                boolean foundMatch = false;
+                for(int j = 0; j < that.params.length; j++){
+                    if(j == i){
+                        continue; //already checked this
+                    }
+                    if(orderGroup.equals(that.pf.parameterOrderGroup[j])){
+                        if(params[i].equals(that.params[j])){
+                            foundMatch = true;
+                            break;
+                        }
+                    }
+                    
+                }
+                if(!foundMatch){
+                    return false;
+                }
+            }
+        }
+        
+        return true;
+        
+    }
 	
 }

--- a/src/burlap/oomdp/core/states/MutableState.java
+++ b/src/burlap/oomdp/core/states/MutableState.java
@@ -307,57 +307,71 @@ public class MutableState extends OOMDPState implements State{
 	}
 	
 	
-	
-	
 	@Override
-	public boolean equals(Object other){
-	
-		if(this == other){
-			return true;
-		}
-		
-		if(!(other instanceof MutableState)){
-			return false;
-		}
-		
-		MutableState so = (MutableState)other;
-		
-		if(this.numTotalObjects() != so.numTotalObjects()){
-			return false;
-		}
-		
-		Set<String> matchedObjects = new HashSet<String>();
-		for(List <ObjectInstance> objects : objectIndexByClass.values()){
-			
-			String oclass = objects.get(0).getClassName();
-			List <ObjectInstance> oobjects = so.getObjectsOfClass(oclass);
-			if(objects.size() != oobjects.size()){
-				return false;
-			}
-			
-			for(ObjectInstance o : objects){
-				boolean foundMatch = false;
-				for(ObjectInstance oo : oobjects){
-					String ooname = oo.getName();
-					if(matchedObjects.contains(ooname)){
-						continue;
-					}
-					if(o.valueEquals(oo)){
-						foundMatch = true;
-						matchedObjects.add(ooname);
-						break;
-					}
-				}
-				if(!foundMatch){
-					return false;
-				}
-			}
-			
-		}
-		
-		
-		return true;
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime
+                * result
+                + ((objectIndexByClass == null) ? 0 : objectIndexByClass
+                        .hashCode());
+        result = prime * result
+                + ((objectInstances == null) ? 0 : objectInstances.hashCode());
+        result = prime * result
+                + ((objectMap == null) ? 0 : objectMap.hashCode());
+        return result;
+    }
+
+
+	@Override
+    public boolean equals(Object other){
+    
+        if(this == other){
+            return true;
+        }
+        
+        if(!(other instanceof MutableState)){
+            return false;
+        }
+        
+        MutableState so = (MutableState)other;
+        
+        if(this.numTotalObjects() != so.numTotalObjects()){
+            return false;
+        }
+        
+        Set<String> matchedObjects = new HashSet<String>();
+        for(List <ObjectInstance> objects : objectIndexByClass.values()){
+            
+            String oclass = objects.get(0).getClassName();
+            List <ObjectInstance> oobjects = so.getObjectsOfClass(oclass);
+            if(objects.size() != oobjects.size()){
+                return false;
+            }
+            
+            for(ObjectInstance o : objects){
+                boolean foundMatch = false;
+                for(ObjectInstance oo : oobjects){
+                    String ooname = oo.getName();
+                    if(matchedObjects.contains(ooname)){
+                        continue;
+                    }
+                    if(o.valueEquals(oo)){
+                        foundMatch = true;
+                        matchedObjects.add(ooname);
+                        break;
+                    }
+                }
+                if(!foundMatch){
+                    return false;
+                }
+            }
+            
+        }
+        
+        
+        return true;
+    }
 	
 	
 	/**

--- a/src/burlap/oomdp/core/values/DiscreteValue.java
+++ b/src/burlap/oomdp/core/values/DiscreteValue.java
@@ -103,24 +103,33 @@ public class DiscreteValue extends OOMDPValue implements Value{
 		return (double)this.discVal;
 	}
 	
+	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		
-		if(!(obj instanceof DiscreteValue)){
-			return false;
-		}
-		
-		DiscreteValue op = (DiscreteValue)obj;
-		if(!op.attribute.equals(attribute)){
-			return false;
-		}
-		
-		return discVal == op.discVal;
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + discVal;
+        return result;
+    }
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        
+        if(!(obj instanceof DiscreteValue)){
+            return false;
+        }
+        
+        DiscreteValue op = (DiscreteValue)obj;
+        if(!op.attribute.equals(attribute)){
+            return false;
+        }
+        
+        return discVal == op.discVal;
+        
+    }
 
 	@Override
 	public boolean getBooleanValue() {

--- a/src/burlap/oomdp/core/values/DoubleArrayValue.java
+++ b/src/burlap/oomdp/core/values/DoubleArrayValue.java
@@ -1,5 +1,7 @@
 package burlap.oomdp.core.values;
 
+import java.util.Arrays;
+
 import burlap.oomdp.core.Attribute;
 
 
@@ -116,31 +118,39 @@ public class DoubleArrayValue extends OOMDPValue{
 	
 	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		if(!(obj instanceof DoubleArrayValue)){
-			return false;
-		}
-		
-		DoubleArrayValue o = (DoubleArrayValue)obj;
-		
-		if(!o.attribute.equals(this.attribute)){
-			return false;
-		}
-		
-		if(this.doubleArray.length != o.doubleArray.length){
-			return false;
-		}
-		
-		for(int i = 0; i < this.doubleArray.length; i++){
-			if(this.doubleArray[i] != o.doubleArray[i]){
-				return false;
-			}
-		}
-		
-		return true;
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(doubleArray);
+        return result;
+    }
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        if(!(obj instanceof DoubleArrayValue)){
+            return false;
+        }
+        
+        DoubleArrayValue o = (DoubleArrayValue)obj;
+        
+        if(!o.attribute.equals(this.attribute)){
+            return false;
+        }
+        
+        if(this.doubleArray.length != o.doubleArray.length){
+            return false;
+        }
+        
+        for(int i = 0; i < this.doubleArray.length; i++){
+            if(this.doubleArray[i] != o.doubleArray[i]){
+                return false;
+            }
+        }
+        
+        return true;
+        
+    }
 }

--- a/src/burlap/oomdp/core/values/IntArrayValue.java
+++ b/src/burlap/oomdp/core/values/IntArrayValue.java
@@ -1,5 +1,6 @@
 package burlap.oomdp.core.values;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -106,33 +107,42 @@ public class IntArrayValue extends OOMDPValue implements Value {
 		return doubleArray;
 	}
 	
+	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		if(!(obj instanceof IntArrayValue)){
-			return false;
-		}
-		
-		IntArrayValue o = (IntArrayValue)obj;
-		
-		if(!o.attribute.equals(attribute)){
-			return false;
-		}
-		
-		if(this.intArray.length != o.intArray.length){
-			return false;
-		}
-		
-		for(int i = 0; i < this.intArray.length; i++){
-			if(this.intArray[i] != o.intArray[i]){
-				return false;
-			}
-		}
-		
-		return true;
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(intArray);
+        return result;
+    }
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        if(!(obj instanceof IntArrayValue)){
+            return false;
+        }
+        
+        IntArrayValue o = (IntArrayValue)obj;
+        
+        if(!o.attribute.equals(attribute)){
+            return false;
+        }
+        
+        if(this.intArray.length != o.intArray.length){
+            return false;
+        }
+        
+        for(int i = 0; i < this.intArray.length; i++){
+            if(this.intArray[i] != o.intArray[i]){
+                return false;
+            }
+        }
+        
+        return true;
+        
+    }
 
 }

--- a/src/burlap/oomdp/core/values/IntValue.java
+++ b/src/burlap/oomdp/core/values/IntValue.java
@@ -93,24 +93,33 @@ public class IntValue extends OOMDPValue implements Value {
 	
 	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		
-		if(!(obj instanceof IntValue)){
-			return false;
-		}
-		
-		IntValue o = (IntValue)obj;
-		
-		if(!o.attribute.equals(attribute)){
-			return false;
-		}
-		
-		return this.intVal == o.intVal;
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + intVal;
+        return result;
+    }
+
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        
+        if(!(obj instanceof IntValue)){
+            return false;
+        }
+        
+        IntValue o = (IntValue)obj;
+        
+        if(!o.attribute.equals(attribute)){
+            return false;
+        }
+        
+        return this.intVal == o.intVal;
+        
+    }
 
 
 	@Override

--- a/src/burlap/oomdp/core/values/MultiTargetRelationalValue.java
+++ b/src/burlap/oomdp/core/values/MultiTargetRelationalValue.java
@@ -122,30 +122,40 @@ public class MultiTargetRelationalValue extends OOMDPValue implements Value{
 	
 	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		if(!(obj instanceof MultiTargetRelationalValue)){
-			return false;
-		}
-		
-		MultiTargetRelationalValue op = (MultiTargetRelationalValue)obj;
-		if(!op.attribute.equals(attribute)){
-			return false;
-		}
-		
-		if(this.targetObjects.size() != op.targetObjects.size()){
-			return false;
-		}
-		
-		for(String t : this.targetObjects){
-			if(!op.targetObjects.contains(t)){
-				return false;
-			}
-		}
-		
-		return true;
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((targetObjects == null) ? 0 : targetObjects.hashCode());
+        return result;
+    }
+
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        if(!(obj instanceof MultiTargetRelationalValue)){
+            return false;
+        }
+        
+        MultiTargetRelationalValue op = (MultiTargetRelationalValue)obj;
+        if(!op.attribute.equals(attribute)){
+            return false;
+        }
+        
+        if(this.targetObjects.size() != op.targetObjects.size()){
+            return false;
+        }
+        
+        for(String t : this.targetObjects){
+            if(!op.targetObjects.contains(t)){
+                return false;
+            }
+        }
+        
+        return true;
+        
+    }
 }

--- a/src/burlap/oomdp/core/values/RealValue.java
+++ b/src/burlap/oomdp/core/values/RealValue.java
@@ -94,21 +94,33 @@ public class RealValue extends OOMDPValue implements Value {
 		return this.realVal;
 	}
 	
+	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		if(!(obj instanceof RealValue)){
-			return false;
-		}
-		
-		RealValue op = (RealValue)obj;
-		if(!op.attribute.equals(attribute)){
-			return false;
-		}
-		
-		return realVal == op.realVal;
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(realVal);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        if(!(obj instanceof RealValue)){
+            return false;
+        }
+        
+        RealValue op = (RealValue)obj;
+        if(!op.attribute.equals(attribute)){
+            return false;
+        }
+        
+        return realVal == op.realVal;
+        
+    }
 }

--- a/src/burlap/oomdp/core/values/RelationalValue.java
+++ b/src/burlap/oomdp/core/values/RelationalValue.java
@@ -94,24 +94,33 @@ public class RelationalValue  extends OOMDPValue implements Value {
 	public double getNumericRepresentation() {
 		return 0;
 	}
-
+	
 	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		if(!(obj instanceof RelationalValue)){
-			return false;
-		}
-		
-		RelationalValue op = (RelationalValue)obj;
-		if(!op.attribute.equals(attribute)){
-			return false;
-		}
-		
-		return this.target.equals(op.target);
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((target == null) ? 0 : target.hashCode());
+        return result;
+    }
+
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        if(!(obj instanceof RelationalValue)){
+            return false;
+        }
+        
+        RelationalValue op = (RelationalValue)obj;
+        if(!op.attribute.equals(attribute)){
+            return false;
+        }
+        
+        return this.target.equals(op.target);
+        
+    }
 
 }

--- a/src/burlap/oomdp/core/values/StringValue.java
+++ b/src/burlap/oomdp/core/values/StringValue.java
@@ -70,22 +70,33 @@ public class StringValue extends OOMDPValue implements Value {
 		return builder.append(this.stringVal);
 	}
 	
+	
 	@Override
-	public boolean equals(Object obj){
-		if (this == obj) {
-			return true;
-		}
-		if(!(obj instanceof StringValue)){
-			return false;
-		}
-		
-		StringValue o = (StringValue)obj;
-		
-		if(!o.attribute.equals(attribute)){
-			return false;
-		}
-		
-		return this.stringVal.equals(o.stringVal);
-		
-	}
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((stringVal == null) ? 0 : stringVal.hashCode());
+        return result;
+    }
+
+
+	@Override
+    public boolean equals(Object obj){
+        if (this == obj) {
+            return true;
+        }
+        if(!(obj instanceof StringValue)){
+            return false;
+        }
+        
+        StringValue o = (StringValue)obj;
+        
+        if(!o.attribute.equals(attribute)){
+            return false;
+        }
+        
+        return this.stringVal.equals(o.stringVal);
+        
+    }
 }

--- a/src/burlap/oomdp/singleagent/ObjectParameterizedAction.java
+++ b/src/burlap/oomdp/singleagent/ObjectParameterizedAction.java
@@ -7,6 +7,7 @@ import burlap.oomdp.core.states.State;
 import burlap.oomdp.singleagent.common.SimpleGroundedAction;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -200,41 +201,50 @@ public abstract class ObjectParameterizedAction extends Action {
 			return buf.toString();
 		}
 
+		
 		@Override
-		public boolean equals(Object other) {
-			if(this == other){
-				return true;
-			}
+        public int hashCode() {
+            final int prime = 31;
+            int result = super.hashCode();
+            result = prime * result + Arrays.hashCode(params);
+            return result;
+        }
 
-			if(!(other instanceof ObjectParameterizedGroundedAction)){
-				return false;
-			}
+		@Override
+        public boolean equals(Object other) {
+            if(this == other){
+                return true;
+            }
 
-			ObjectParameterizedGroundedAction go = (ObjectParameterizedGroundedAction)other;
+            if(!(other instanceof ObjectParameterizedGroundedAction)){
+                return false;
+            }
 
-			if(!this.action.getName().equals(go.action.getName())){
-				return false;
-			}
+            ObjectParameterizedGroundedAction go = (ObjectParameterizedGroundedAction)other;
 
-			String [] pog = ((ObjectParameterizedAction)this.action).getParameterOrderGroups();
+            if(!this.action.getName().equals(go.action.getName())){
+                return false;
+            }
 
-			for(int i = 0; i < this.params.length; i++){
-				String p = this.params[i];
-				String orderGroup = pog[i];
-				boolean foundMatch = false;
-				for(int j = 0; j < go.params.length; j++){
-					if(p.equals(go.params[j]) && orderGroup.equals(pog[j])){
-						foundMatch = true;
-						break;
-					}
-				}
-				if(!foundMatch){
-					return false;
-				}
-			}
+            String [] pog = ((ObjectParameterizedAction)this.action).getParameterOrderGroups();
 
-			return true;
-		}
+            for(int i = 0; i < this.params.length; i++){
+                String p = this.params[i];
+                String orderGroup = pog[i];
+                boolean foundMatch = false;
+                for(int j = 0; j < go.params.length; j++){
+                    if(p.equals(go.params[j]) && orderGroup.equals(pog[j])){
+                        foundMatch = true;
+                        break;
+                    }
+                }
+                if(!foundMatch){
+                    return false;
+                }
+            }
+
+            return true;
+        }
 
 		@Override
 		public GroundedAction copy() {

--- a/src/burlap/oomdp/stochasticgames/agentactions/ObParamSGAgentAction.java
+++ b/src/burlap/oomdp/stochasticgames/agentactions/ObParamSGAgentAction.java
@@ -6,6 +6,7 @@ import burlap.oomdp.core.states.State;
 import burlap.oomdp.stochasticgames.SGDomain;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -190,46 +191,54 @@ public abstract class ObParamSGAgentAction extends SGAgentAction {
 
 
 		@Override
-		public boolean equals(Object other){
+        public int hashCode() {
+            final int prime = 31;
+            int result = super.hashCode();
+            result = prime * result + Arrays.hashCode(params);
+            return result;
+        }
 
-			if(this == other){
-				return true;
-			}
+		@Override
+        public boolean equals(Object other){
 
-			if(!(other instanceof GroundedObParamSGAgentAction)){
-				return false;
-			}
+            if(this == other){
+                return true;
+            }
 
-			GroundedObParamSGAgentAction go = (GroundedObParamSGAgentAction)other;
+            if(!(other instanceof GroundedObParamSGAgentAction)){
+                return false;
+            }
 
-			if(!this.actingAgent.equals(go.actingAgent)){
-				return false;
-			}
+            GroundedObParamSGAgentAction go = (GroundedObParamSGAgentAction)other;
 
-			if(!this.action.actionName.equals(go.action.actionName)){
-				return false;
-			}
+            if(!this.actingAgent.equals(go.actingAgent)){
+                return false;
+            }
 
-			String [] rclasses = ((ObParamSGAgentAction)this.action).parameterOrderGroups;
+            if(!this.action.actionName.equals(go.action.actionName)){
+                return false;
+            }
 
-			for(int i = 0; i < this.params.length; i++){
-				String p = this.params[i];
-				String replaceClass = rclasses[i];
-				boolean foundMatch = false;
-				for(int j = 0; j < go.params.length; j++){
-					if(p.equals(go.params[j]) && replaceClass.equals(rclasses[j])){
-						foundMatch = true;
-						break;
-					}
-				}
-				if(!foundMatch){
-					return false;
-				}
+            String [] rclasses = ((ObParamSGAgentAction)this.action).parameterOrderGroups;
 
-			}
+            for(int i = 0; i < this.params.length; i++){
+                String p = this.params[i];
+                String replaceClass = rclasses[i];
+                boolean foundMatch = false;
+                for(int j = 0; j < go.params.length; j++){
+                    if(p.equals(go.params[j]) && replaceClass.equals(rclasses[j])){
+                        foundMatch = true;
+                        break;
+                    }
+                }
+                if(!foundMatch){
+                    return false;
+                }
 
-			return true;
-		}
+            }
+
+            return true;
+        }
 	}
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1206- "equals(Object obj)" and "hashCode()" should be overridden in pairs
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1206

Please let me know if you have any questions.

Faisal Hameed