### PR TITLE
Code quality fix - Redundant casts should not be used

### DIFF
--- a/src/burlap/oomdp/core/values/DiscreteValue.java
+++ b/src/burlap/oomdp/core/values/DiscreteValue.java
@@ -35,7 +35,7 @@ public class DiscreteValue extends OOMDPValue implements Value{
 	 */
 	public DiscreteValue(DiscreteValue v){
 		super(v);
-		DiscreteValue dv = (DiscreteValue)v;
+		DiscreteValue dv = v;
 		this.discVal = dv.discVal;
 	}
 	

--- a/src/burlap/oomdp/core/values/DoubleArrayValue.java
+++ b/src/burlap/oomdp/core/values/DoubleArrayValue.java
@@ -22,7 +22,7 @@ public class DoubleArrayValue extends OOMDPValue{
 	
 	public DoubleArrayValue(DoubleArrayValue v){
 		super(v);
-		DoubleArrayValue daValue = (DoubleArrayValue)v;
+		DoubleArrayValue daValue = v;
 		if(daValue.doubleArray != null) {
 			this.doubleArray = daValue.doubleArray.clone();
 		} else {

--- a/src/burlap/oomdp/core/values/IntArrayValue.java
+++ b/src/burlap/oomdp/core/values/IntArrayValue.java
@@ -25,7 +25,7 @@ public class IntArrayValue extends OOMDPValue implements Value {
 	
 	public IntArrayValue(IntArrayValue v){
 		super(v);
-		IntArrayValue iaValue  = (IntArrayValue)v;
+		IntArrayValue iaValue  = v;
 		if(iaValue.intArray != null){
 			this.intArray = iaValue.intArray.clone();
 		} else {

--- a/src/burlap/oomdp/core/values/IntValue.java
+++ b/src/burlap/oomdp/core/values/IntValue.java
@@ -38,7 +38,7 @@ public class IntValue extends OOMDPValue implements Value {
 	 */
 	public IntValue(IntValue v) {
 		super(v);
-		this.intVal = ((IntValue)v).intVal;
+		this.intVal = v.intVal;
 	}
 	
 	public IntValue(Attribute attribute, int intVal) {

--- a/src/burlap/oomdp/core/values/MultiTargetRelationalValue.java
+++ b/src/burlap/oomdp/core/values/MultiTargetRelationalValue.java
@@ -40,7 +40,7 @@ public class MultiTargetRelationalValue extends OOMDPValue implements Value{
 	 */
 	public MultiTargetRelationalValue(MultiTargetRelationalValue v){
 		super(v);
-		MultiTargetRelationalValue rv = (MultiTargetRelationalValue)v;
+		MultiTargetRelationalValue rv = v;
 		this.targetObjects = rv.targetObjects;
 	}
 	

--- a/src/burlap/oomdp/core/values/RealValue.java
+++ b/src/burlap/oomdp/core/values/RealValue.java
@@ -35,7 +35,7 @@ public class RealValue extends OOMDPValue implements Value {
 	 */
 	public RealValue(RealValue v){
 		super(v);
-		RealValue rv = (RealValue)v;
+		RealValue rv = v;
 		this.realVal = rv.realVal;
 	}
 	

--- a/src/burlap/oomdp/core/values/RelationalValue.java
+++ b/src/burlap/oomdp/core/values/RelationalValue.java
@@ -38,7 +38,7 @@ public class RelationalValue  extends OOMDPValue implements Value {
 	 */
 	public RelationalValue(RelationalValue v){
 		super(v);
-		RelationalValue rv = (RelationalValue)v;
+		RelationalValue rv = v;
 		this.target = rv.target;
 	}
 	

--- a/src/burlap/oomdp/core/values/StringValue.java
+++ b/src/burlap/oomdp/core/values/StringValue.java
@@ -32,7 +32,7 @@ public class StringValue extends OOMDPValue implements Value {
 	 */
 	public StringValue(StringValue v) {
 		super(v);
-		this.stringVal = ((StringValue)v).stringVal;
+		this.stringVal = v.stringVal;
 	}
 	
 	public StringValue(Attribute attribute, String stringVal) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1905 - Redundant casts should not be used
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1905

Please let me know if you have any questions.

Faisal Hameed