### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/src/burlap/behavior/stochasticgames/solvers/CorrelatedEquilibriumSolver.java
+++ b/src/burlap/behavior/stochasticgames/solvers/CorrelatedEquilibriumSolver.java
@@ -532,7 +532,7 @@ public class CorrelatedEquilibriumSolver {
 			int r = rc[0];
 			int c = rc[1];
 			
-			objective[i] = (payoffRow[r][c] + payoffCol[r][c]);
+			objective[i] = payoffRow[r][c] + payoffCol[r][c];
 		}
 		
 		

--- a/src/burlap/datastructures/HashIndexedHeap.java
+++ b/src/burlap/datastructures/HashIndexedHeap.java
@@ -337,7 +337,7 @@ public class HashIndexedHeap <T> implements Iterable<T>{
 	}
 	
 	private int right(int i ){
-		return (2*(i+1));
+		return 2*(i+1);
 	}
 
 	

--- a/src/burlap/domain/singleagent/cartpole/InvertedPendulum.java
+++ b/src/burlap/domain/singleagent/cartpole/InvertedPendulum.java
@@ -320,7 +320,7 @@ public class InvertedPendulum implements DomainGenerator {
 		/**
 		 * The maximum pole angle to cause termination/failure.
 		 */
-		double maxAbsoluteAngle = (Math.PI / 2.);
+		double maxAbsoluteAngle = Math.PI / 2.;
 		
 		public InvertedPendulumTerminalFunction() {
 
@@ -364,7 +364,7 @@ public class InvertedPendulum implements DomainGenerator {
 		/**
 		 * The maximum pole angle to cause termination/failure.
 		 */
-		double maxAbsoluteAngle = (Math.PI / 2.);
+		double maxAbsoluteAngle = Math.PI / 2.;
 		
 		public InvertedPendulumRewardFunction() {
 

--- a/src/burlap/domain/singleagent/lunarlander/LLVisualizer.java
+++ b/src/burlap/domain/singleagent/lunarlander/LLVisualizer.java
@@ -198,8 +198,8 @@ public class LLVisualizer {
 			double ow = or - ol;
 			double oh = ot - obb;
 			
-			double xr = (lld.getXmax() - lld.getXmin());
-			double yr = (lld.getYmax() - lld.getYmin());
+			double xr = lld.getXmax() - lld.getXmin();
+			double yr = lld.getYmax() - lld.getYmin();
 			
 			double nl = (ol - lld.getXmin()) / xr;
 			double nt = (ot - lld.getYmin()) / yr;
@@ -207,7 +207,7 @@ public class LLVisualizer {
 			double nw = ow/xr;
 			double nh = oh/yr;
 			
-			double sx = (nl*cWidth);
+			double sx = nl*cWidth;
 			double sy = cHeight - (nt*cHeight);
 			
 			double sw = nw*cWidth;
@@ -250,8 +250,8 @@ public class LLVisualizer {
 			double ow = or - ol;
 			double oh = ot - obb;
 			
-			double xr = (lld.getXmax() - lld.getXmin());
-			double yr = (lld.getYmax() - lld.getYmin());
+			double xr = lld.getXmax() - lld.getXmin();
+			double yr = lld.getYmax() - lld.getYmin();
 			
 			double nl = (ol - lld.getXmin()) / xr;
 			double nt = (ot - lld.getYmin()) / yr;
@@ -259,7 +259,7 @@ public class LLVisualizer {
 			double nw = ow/xr;
 			double nh = oh/yr;
 			
-			double sx = (nl*cWidth);
+			double sx = nl*cWidth;
 			double sy = cHeight - (nt*cHeight);
 			
 			double sw = nw*cWidth;

--- a/src/burlap/domain/singleagent/mountaincar/MountainCarVisualizer.java
+++ b/src/burlap/domain/singleagent/mountaincar/MountainCarVisualizer.java
@@ -166,10 +166,10 @@ public class MountainCarVisualizer {
 				double nx1 = (p1.x - this.physParams.xmin) / (range);
 				double ny1 = (p1.y + 1) / 2;
 				
-				double sx0 = (nx0 * cWidth);
+				double sx0 = nx0 * cWidth;
 				double sy0 = (cHeight) - (ny0 * (cHeight-30)+15);
 				
-				double sx1 = (nx1 * cWidth);
+				double sx1 = nx1 * cWidth;
 				double sy1 = (cHeight) - (ny1 * (cHeight-30)+15);
 				
 				g2.draw(new Line2D.Double(sx0, sy0, sx1, sy1));

--- a/src/burlap/oomdp/core/values/DiscreteValue.java
+++ b/src/burlap/oomdp/core/values/DiscreteValue.java
@@ -66,7 +66,7 @@ public class DiscreteValue extends OOMDPValue implements Value{
 	
 	@Override
 	public Value setValue(boolean v) {
-		int intV = (v) ? 1 : 0;
+		int intV = v ? 1 : 0;
 		return new DiscreteValue(this.attribute, intV);
 	}
 	

--- a/src/burlap/oomdp/core/values/IntValue.java
+++ b/src/burlap/oomdp/core/values/IntValue.java
@@ -73,7 +73,7 @@ public class IntValue extends OOMDPValue implements Value {
 	
 	@Override
 	public Value setValue(boolean v) {
-		return new IntValue(this.attribute, (v) ? 1 : 0);
+		return new IntValue(this.attribute, v ? 1 : 0);
 	}
 
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed