### PR TITLE
Code quality fix - "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/src/burlap/behavior/singleagent/vfa/cmac/Tiling.java
+++ b/src/burlap/behavior/singleagent/vfa/cmac/Tiling.java
@@ -5,6 +5,7 @@ import burlap.oomdp.core.objects.ObjectInstance;
 import burlap.oomdp.core.states.State;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 
 /**
@@ -302,9 +303,9 @@ public class Tiling {
 				return false;
 			}
 			
-			for(String attName : this.attTiles.keySet()){
-				int tv = this.attTiles.get(attName);
-				int ttv = that.attTiles.get(attName);
+			for(Entry<String, Integer> attr : this.attTiles.entrySet()){
+				int tv = attr.getValue();
+				int ttv = that.attTiles.get(attr.getKey());
 				if(tv != ttv){
 					return false;
 				}

--- a/src/burlap/behavior/stochasticgames/agents/naiveq/history/ParameterNaiveActionIdMap.java
+++ b/src/burlap/behavior/stochasticgames/agents/naiveq/history/ParameterNaiveActionIdMap.java
@@ -3,6 +3,7 @@ package burlap.behavior.stochasticgames.agents.naiveq.history;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import burlap.oomdp.core.Domain;
 import burlap.oomdp.stochasticgames.agentactions.GroundedSGAgentAction;
@@ -64,11 +65,11 @@ public class ParameterNaiveActionIdMap implements ActionIdMap {
 	@Override
 	public GroundedSGAgentAction getActionForId(int id) {
 		
-		for(String key : map.keySet()){
-			int sid = map.get(key);
+		for(Entry<String, Integer> action : map.entrySet()){
+			int sid = action.getValue();
 			if(sid == id){
 				//found it
-				GroundedSGAgentAction gsa = new SimpleGroundedSGAgentAction("", domain.getSingleAction(key));
+				GroundedSGAgentAction gsa = new SimpleGroundedSGAgentAction("", domain.getSingleAction(action.getKey()));
 				return gsa;
 			}
 		}

--- a/src/burlap/oomdp/stochasticgames/World.java
+++ b/src/burlap/oomdp/stochasticgames/World.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 
 /**
@@ -419,9 +420,9 @@ public class World {
 		DPrint.cl(debugId, jointReward.toString());
 		
 		//index reward
-		for(String aname : jointReward.keySet()){
-			double r = jointReward.get(aname);
-			agentCumulativeReward.add(aname, r);
+		for(Entry<String, Double> ar : jointReward.entrySet()){
+			double r = ar.getValue();
+			agentCumulativeReward.add(ar.getKey(), r);
 		}
 		
 		//tell all the agents about it
@@ -468,9 +469,9 @@ public class World {
 		DPrint.cl(debugId, jointReward.toString());
 		
 		//index reward
-		for(String aname : jointReward.keySet()){
-			double r = jointReward.get(aname);
-			agentCumulativeReward.add(aname, r);
+		for(Entry<String, Double> ar : jointReward.entrySet()){
+			double r = ar.getValue();
+			agentCumulativeReward.add(ar.getKey(), r);
 		}
 		
 		

--- a/src/burlap/oomdp/stochasticgames/tournament/Tournament.java
+++ b/src/burlap/oomdp/stochasticgames/tournament/Tournament.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import burlap.debugtools.DPrint;
 import burlap.debugtools.RandomFactory;
@@ -204,9 +205,9 @@ public class Tournament {
 			}
 			
 			//record results
-			for(String aname : agentNameToId.keySet()){
-				int aId = agentNameToId.get(aname);
-				double gameCumR = w.getCumulativeRewardForAgent(aname);
+			for(Entry<String, Integer> an : agentNameToId.entrySet()){
+				int aId = an.getValue();
+				double gameCumR = w.getCumulativeRewardForAgent(an.getKey());
 				double tournCumR = tournamentCumulatedReward.get(aId);
 				tournamentCumulatedReward.set(aId, gameCumR+tournCumR);
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed