### PR TITLE
Code quality fix - Methods and field names should not be the same or differ only by capitalization.

### DIFF
--- a/src/burlap/behavior/singleagent/MDPSolver.java
+++ b/src/burlap/behavior/singleagent/MDPSolver.java
@@ -132,18 +132,6 @@ public abstract class MDPSolver implements MDPSolverInterface{
 	public List<Action> getActions(){
 		return new ArrayList<Action>(this.actions);
 	}
-	
-	@Override
-	public TerminalFunction getTF(){
-		return tf;
-	}
-	
-	
-	@Override
-	public RewardFunction getRF(){
-		return rf;
-	}
-
 
 	@Override
 	public void setHashingFactory(HashableStateFactory hashingFactory) {

--- a/src/burlap/behavior/singleagent/MDPSolverInterface.java
+++ b/src/burlap/behavior/singleagent/MDPSolverInterface.java
@@ -72,20 +72,6 @@ public interface MDPSolverInterface {
 
 
 	/**
-	 * Returns the {@link burlap.oomdp.core.TerminalFunction} this solver uses.
-	 * @return the {@link burlap.oomdp.core.TerminalFunction} this solver uses.
-	 */
-	TerminalFunction getTF();
-
-
-	/**
-	 * Returns the {@link burlap.oomdp.singleagent.RewardFunction} this solver uses.
-	 * @return the {@link burlap.oomdp.singleagent.RewardFunction} this solver uses.
-	 */
-	RewardFunction getRF();
-
-
-	/**
 	 * Sets the {@link burlap.oomdp.statehashing.HashableStateFactory} used to hash states for tabular solvers.
 	 * @param hashingFactory the {@link burlap.oomdp.statehashing.HashableStateFactory} used to hash states for tabular solvers.
 	 */

--- a/src/burlap/behavior/singleagent/learnfromdemo/apprenticeship/ApprenticeshipLearning.java
+++ b/src/burlap/behavior/singleagent/learnfromdemo/apprenticeship/ApprenticeshipLearning.java
@@ -180,7 +180,7 @@ public class ApprenticeshipLearning {
 		}
 
 		Planner planner = request.getPlanner();
-		TerminalFunction terminalFunction = planner.getTF();
+		TerminalFunction terminalFunction = planner.getTf();
 		HashableStateFactory stateHashingFactory = planner.getHashingFactory();
 
 		// (1). Randomly generate policy pi^(0)
@@ -281,7 +281,7 @@ public class ApprenticeshipLearning {
 
 		//Planning objects
 		Planner planner = request.getPlanner();
-		TerminalFunction terminalFunction = planner.getTF();
+		TerminalFunction terminalFunction = planner.getTf();
 		HashableStateFactory stateHashingFactory = planner.getHashingFactory();
 
 		//(0) set up policy array; exper feature expectation

--- a/src/burlap/behavior/singleagent/pomdp/qmdp/QMDP.java
+++ b/src/burlap/behavior/singleagent/pomdp/qmdp/QMDP.java
@@ -47,7 +47,7 @@ public class QMDP extends MDPSolver implements Planner, QFunction {
 	public QMDP(PODomain domain, QFunction mdpQSource){
 		this.mdpQSource = mdpQSource;
 		Planner planner = (Planner)this.mdpQSource;
-		this.solverInit(domain, planner.getRF(), planner.getTF(), planner.getGamma(), planner.getHashingFactory());
+		this.solverInit(domain, planner.getRf(), planner.getTf(), planner.getGamma(), planner.getHashingFactory());
 	}
 
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1845 - Methods and field names should not be the same or differ only by capitalization.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1845

Please let me know if you have any questions.

Faisal Hameed