### PR TITLE
Code quality fix - "equals(Object obj)" should test argument type.

### DIFF
--- a/src/burlap/behavior/singleagent/planning/deterministic/SearchNode.java
+++ b/src/burlap/behavior/singleagent/planning/deterministic/SearchNode.java
@@ -59,6 +59,9 @@ public class SearchNode {
 	
 	@Override
 	public boolean equals(Object o){
+	    if (o == null || this.getClass() != o.getClass()) {
+	        return false;   
+	    }
 		SearchNode so = (SearchNode)o;
 		return s.equals(so.s);
 	}

--- a/src/burlap/behavior/singleagent/planning/deterministic/informed/PrioritizedSearchNode.java
+++ b/src/burlap/behavior/singleagent/planning/deterministic/informed/PrioritizedSearchNode.java
@@ -59,6 +59,9 @@ public class PrioritizedSearchNode extends SearchNode {
 	
 	@Override
 	public boolean equals(Object o){
+	    if (o == null || this.getClass() != o.getClass()) {
+            return false;   
+        }
 		PrioritizedSearchNode po = (PrioritizedSearchNode)o;
 		return s.equals(po.s);
 	}

--- a/src/burlap/behavior/singleagent/planning/stochastic/sparsesampling/SparseSampling.java
+++ b/src/burlap/behavior/singleagent/planning/stochastic/sparsesampling/SparseSampling.java
@@ -613,6 +613,9 @@ public class SparseSampling extends MDPSolver implements QFunction, Planner {
 		
 		@Override
 		public boolean equals(Object other){
+		    if (other == null || this.getClass() != other.getClass()) {
+	            return false;   
+	        }
 			HashedHeightState o = (HashedHeightState)other;
 			return this.height == o.height && this.sh.equals(o.sh);
 		}

--- a/src/burlap/behavior/singleagent/planning/stochastic/valueiteration/PrioritizedSweeping.java
+++ b/src/burlap/behavior/singleagent/planning/stochastic/valueiteration/PrioritizedSweeping.java
@@ -243,6 +243,9 @@ public class PrioritizedSweeping extends ValueIteration{
 		
 		@Override
 		public boolean equals(Object other){
+		    if (other == null || this.getClass() != other.getClass()) {
+                return false;   
+            }
 			BPTRNode o = (BPTRNode)other;
 			return this.sh.equals(o.sh);
 		}

--- a/src/burlap/oomdp/core/Attribute.java
+++ b/src/burlap/oomdp/core/Attribute.java
@@ -373,6 +373,9 @@ public class Attribute {
 		if (this == obj) {
 			return true;
 		}
+		if (obj == null || this.getClass() != obj.getClass()) {
+            return false;   
+        }
 		Attribute op = (Attribute)obj;
 		if(op.name.equals(name))
 			return true;

--- a/src/burlap/oomdp/core/objects/MutableObjectInstance.java
+++ b/src/burlap/oomdp/core/objects/MutableObjectInstance.java
@@ -463,6 +463,9 @@ public class MutableObjectInstance extends OOMDPObjectInstance implements Object
 	
 	@Override
 	public boolean equals(Object obj){
+	    if (obj == null || this.getClass() != obj.getClass()) {
+            return false;   
+        }
 		MutableObjectInstance op = (MutableObjectInstance)obj;
 		if(op.name.equals(name))
 			return true;

--- a/src/burlap/oomdp/singleagent/Action.java
+++ b/src/burlap/oomdp/singleagent/Action.java
@@ -322,6 +322,9 @@ public abstract class Action{
 	
 	@Override
 	public boolean equals(Object obj){
+	    if (obj == null || this.getClass() != obj.getClass()) {
+            return false;   
+        }
 		Action op = (Action)obj;
 		if(op.name.equals(name))
 			return true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2097 - "equals(Object obj)" should test argument type. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2097

Please let me know if you have any questions.

Faisal Hameed