### PR TITLE
Code quality fix - Literal boolean values should not be used in condition expressions.

### DIFF
--- a/src/burlap/behavior/singleagent/auxiliary/EpisodeSequenceVisualizer.java
+++ b/src/burlap/behavior/singleagent/auxiliary/EpisodeSequenceVisualizer.java
@@ -320,7 +320,7 @@ public class EpisodeSequenceVisualizer extends JFrame{
 
 	protected void handleEpisodeSelection(ListSelectionEvent e){
 		
-		if (e.getValueIsAdjusting() == false) {
+		if (!e.getValueIsAdjusting()) {
 
 			int ind = episodeList.getSelectedIndex();
 			//System.out.println("epsidoe id: " + ind);
@@ -351,7 +351,7 @@ public class EpisodeSequenceVisualizer extends JFrame{
 
 	protected void handleIterationSelection(ListSelectionEvent e){
 		
-		if (e.getValueIsAdjusting() == false) {
+		if (!e.getValueIsAdjusting()) {
 
        		if (iterationList.getSelectedIndex() != -1) {
 				//System.out.println("Changing visualization...");

--- a/src/burlap/behavior/singleagent/auxiliary/performance/PerformancePlotter.java
+++ b/src/burlap/behavior/singleagent/auxiliary/performance/PerformancePlotter.java
@@ -402,7 +402,7 @@ public class PerformancePlotter extends JFrame implements EnvironmentObserver {
 			
 		//wait until it's updated before allowing anything else to happen
 		synchronized (this.trialUpdateComplete) {
-			while(this.trialUpdateComplete.b == false){
+			while(!this.trialUpdateComplete.b){
 				try {
 					this.trialUpdateComplete.wait();
 				} catch (InterruptedException e) {

--- a/src/burlap/behavior/stochasticgames/auxiliary/GameSequenceVisualizer.java
+++ b/src/burlap/behavior/stochasticgames/auxiliary/GameSequenceVisualizer.java
@@ -321,7 +321,7 @@ public class GameSequenceVisualizer extends JFrame {
 	
 	private void handleEpisodeSelection(ListSelectionEvent e){
 		
-		if (e.getValueIsAdjusting() == false) {
+		if (!e.getValueIsAdjusting()) {
 
 			int ind = episodeList.getSelectedIndex();
 			//System.out.println("epsidoe id: " + ind);
@@ -352,7 +352,7 @@ public class GameSequenceVisualizer extends JFrame {
 	
 	private void handleIterationSelection(ListSelectionEvent e){
 		
-		if (e.getValueIsAdjusting() == false) {
+		if (!e.getValueIsAdjusting()) {
 
        		if (iterationList.getSelectedIndex() != -1) {
 				//System.out.println("Changing visualization...");

--- a/src/burlap/behavior/stochasticgames/auxiliary/performance/MultiAgentPerformancePlotter.java
+++ b/src/burlap/behavior/stochasticgames/auxiliary/performance/MultiAgentPerformancePlotter.java
@@ -625,7 +625,7 @@ public class MultiAgentPerformancePlotter extends JFrame implements WorldObserve
 			
 		//wait until it's updated before allowing anything else to happen
 		synchronized (this.trialUpdateComplete) {
-			while(this.trialUpdateComplete.b == false){
+			while(!this.trialUpdateComplete.b){
 				try {
 					this.trialUpdateComplete.wait();
 				} catch (InterruptedException e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed