### PR TITLE
Code quality fix - Array designators "[]" should be on the type, not the variable.

### DIFF
--- a/src/burlap/datastructures/StochasticTree.java
+++ b/src/burlap/datastructures/StochasticTree.java
@@ -418,7 +418,7 @@ public class StochasticTree <T>{
 	 * Demos how to use this class
 	 * @param args empty
 	 */
-	public static void main(String args []){
+	public static void main(String[] args){
 		
 		System.out.println("Starting");
 		test2();

--- a/src/burlap/oomdp/singleagent/explorer/VisualExplorer.java
+++ b/src/burlap/oomdp/singleagent/explorer/VisualExplorer.java
@@ -452,7 +452,7 @@ public class VisualExplorer extends JFrame implements ShellObserver{
 		String actionName = comps[0];
 
 		//construct parameter list as all that remains
-		String params[];
+		String[] params;
 		if(comps.length > 1){
 			params = new String[comps.length-1];
 			for(int i = 1; i < comps.length; i++){
@@ -488,7 +488,7 @@ public class VisualExplorer extends JFrame implements ShellObserver{
 		String actionName = comps[0];
 
 		//construct parameter list as all that remains
-		String params[];
+		String[] params;
 		if(comps.length > 1){
 			params = new String[comps.length-1];
 			for(int i = 1; i < comps.length; i++){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed