### PR TITLE
Code quality fix - Primitives should not be boxed just for "String" conversion.

### DIFF
--- a/src/burlap/behavior/singleagent/interfaces/rlglue/RLGlueDomain.java
+++ b/src/burlap/behavior/singleagent/interfaces/rlglue/RLGlueDomain.java
@@ -148,7 +148,7 @@ public class RLGlueDomain implements DomainGenerator {
 		 * @param ind the RLGlue int identifier of the action
 		 */
 		public RLGlueActionSpecification(Domain domain, int ind) {
-			super(""+ind, domain);
+			super(String.valueOf(ind), domain);
 			this.ind = ind;
 		}
 

--- a/src/burlap/behavior/singleagent/planning/stochastic/montecarlo/uct/UCT.java
+++ b/src/burlap/behavior/singleagent/planning/stochastic/montecarlo/uct/UCT.java
@@ -161,7 +161,7 @@ public class UCT extends MDPSolver implements Planner, QFunction {
 			
 			int nu = uniqueStatesInTree.size();
 			if(nu - lastNumUnique > 0){
-				DPrint.cl(debugCode, "" + numRollOutsFromRoot + "; unique states: " + nu  + "; tree size: " + treeSize + "; total visits: " + numVisits);
+				DPrint.cl(debugCode, String.valueOf(numRollOutsFromRoot) + "; unique states: " + nu  + "; tree size: " + treeSize + "; total visits: " + numVisits);
 				lastNumUnique = nu;
 			}
 			

--- a/src/burlap/datastructures/AlphanumericSorting.java
+++ b/src/burlap/datastructures/AlphanumericSorting.java
@@ -94,7 +94,7 @@ public class AlphanumericSorting implements Comparator {
 	private String removePadding(String string) {
 		String result="";
 		try{
-			result+= Integer.parseInt(string.trim());
+			result = Integer.toString(Integer.parseInt(string.trim()));
 		} catch (Exception e) {
 			result= string;
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed