### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/src/burlap/behavior/singleagent/EpisodeAnalysis.java
+++ b/src/burlap/behavior/singleagent/EpisodeAnalysis.java
@@ -255,7 +255,7 @@ public class EpisodeAnalysis {
 	 * @return a string representing the actions taken in this episode
 	 */
 	public String getActionSequenceString(String delimiter){
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		boolean first = true;
 		for(GroundedAction ga : actionSequence){
 			if(!first){

--- a/src/burlap/behavior/singleagent/auxiliary/EpisodeSequenceVisualizer.java
+++ b/src/burlap/behavior/singleagent/auxiliary/EpisodeSequenceVisualizer.java
@@ -379,7 +379,7 @@ public class EpisodeSequenceVisualizer extends JFrame{
 
 	protected void updatePropTextArea(State s){
 		
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		
 		List <PropositionalFunction> props = domain.getPropFunctions();
 		for(PropositionalFunction pf : props){

--- a/src/burlap/behavior/stochasticgames/GameAnalysis.java
+++ b/src/burlap/behavior/stochasticgames/GameAnalysis.java
@@ -512,7 +512,7 @@ public class GameAnalysis {
 	 * @return a string representation of the joint reward
 	 */
 	private static String jointRewardStringRep(Map<String, Double> jointReward){
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		boolean doneFirst = false;
 		for(Map.Entry<String, Double> e : jointReward.entrySet()){
 			if(doneFirst){

--- a/src/burlap/behavior/stochasticgames/auxiliary/GameSequenceVisualizer.java
+++ b/src/burlap/behavior/stochasticgames/auxiliary/GameSequenceVisualizer.java
@@ -380,7 +380,7 @@ public class GameSequenceVisualizer extends JFrame {
 	
 	private void updatePropTextArea(State s){
 		
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		
 		List <PropositionalFunction> props = domain.getPropFunctions();
 		for(PropositionalFunction pf : props){

--- a/src/burlap/domain/singleagent/frostbite/SerializableFrostbiteStateFactory.java
+++ b/src/burlap/domain/singleagent/frostbite/SerializableFrostbiteStateFactory.java
@@ -72,7 +72,7 @@ public class SerializableFrostbiteStateFactory implements SerializableStateFacto
 
 
 	public static String stateToString(State s){
-		StringBuffer buf = new StringBuffer(256);
+	    StringBuilder buf = new StringBuilder(256);
 
 		ObjectInstance agent = s.getObjectsOfClass(FrostbiteDomain.AGENTCLASS).get(0);
 		ObjectInstance igloo = s.getObjectsOfClass(FrostbiteDomain.IGLOOCLASS).get(0);

--- a/src/burlap/domain/singleagent/lunarlander/SerializableLunarLanderStateFactory.java
+++ b/src/burlap/domain/singleagent/lunarlander/SerializableLunarLanderStateFactory.java
@@ -73,7 +73,7 @@ public class SerializableLunarLanderStateFactory implements SerializableStateFac
 
 
 	public static String stateToString(State s){
-		StringBuffer buf = new StringBuffer(256);
+	    StringBuilder buf = new StringBuilder(256);
 
 		ObjectInstance agent = s.getObjectsOfClass(LunarLanderDomain.AGENTCLASS).get(0);
 		ObjectInstance pad = s.getObjectsOfClass(LunarLanderDomain.PADCLASS).get(0);

--- a/src/burlap/domain/stochasticgames/normalform/SingleStageNormalFormGame.java
+++ b/src/burlap/domain/stochasticgames/normalform/SingleStageNormalFormGame.java
@@ -814,7 +814,7 @@ public class SingleStageNormalFormGame implements DomainGenerator {
 			if(this.profile.length == 0){
 				return "";
 			}
-			StringBuffer buf = new StringBuffer(3*this.profile.length);
+			StringBuilder buf = new StringBuilder(3*this.profile.length);
 			buf.append(this.profile[0]);
 			
 			for(int i = 1; i < this.profile.length; i++){

--- a/src/burlap/oomdp/core/GroundedProp.java
+++ b/src/burlap/oomdp/core/GroundedProp.java
@@ -49,7 +49,7 @@ public class GroundedProp implements Cloneable{
 	 * then the returned format is: "PFName(ob1, ob2)"
 	 */
 	public String toString(){
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		
 		buf.append(pf.name).append("(");
 		for(int i = 0; i < params.length; i++){

--- a/src/burlap/oomdp/singleagent/common/VisualActionObserver.java
+++ b/src/burlap/oomdp/singleagent/common/VisualActionObserver.java
@@ -299,7 +299,7 @@ public class VisualActionObserver extends JFrame implements ActionObserver, Envi
 	
 	private void updatePropTextArea(State s){
 		
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		
 		List <PropositionalFunction> props = domain.getPropFunctions();
 		for(PropositionalFunction pf : props){

--- a/src/burlap/oomdp/singleagent/explorer/VisualExplorer.java
+++ b/src/burlap/oomdp/singleagent/explorer/VisualExplorer.java
@@ -542,7 +542,7 @@ public class VisualExplorer extends JFrame implements ShellObserver{
 	 */
 	protected void updatePropTextArea(State s){
 		
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		
 		List <PropositionalFunction> props = domain.getPropFunctions();
 		for(PropositionalFunction pf : props){

--- a/src/burlap/oomdp/stochasticgames/JointAction.java
+++ b/src/burlap/oomdp/stochasticgames/JointAction.java
@@ -99,7 +99,7 @@ public class JointAction implements AbstractGroundedAction, Iterable<GroundedSGA
 	 * @return a string representation of this joint aciton without including the parameters of any parameterized actions
 	 */
 	public String noParametersActionDescription(){
-		StringBuffer buf = new StringBuffer(100);
+	    StringBuilder buf = new StringBuilder(100);
 		List <GroundedSGAgentAction> gsas = this.getActionList();
 		for(int i = 0; i < gsas.size(); i++){
 			if(i > 0){
@@ -113,7 +113,7 @@ public class JointAction implements AbstractGroundedAction, Iterable<GroundedSGA
 	
 	@Override
 	public String toString(){
-		StringBuffer buf = new StringBuffer(100);
+	    StringBuilder buf = new StringBuilder(100);
 		List <GroundedSGAgentAction> gsas = this.getActionList();
 		for(int i = 0; i < gsas.size(); i++){
 			if(i > 0){

--- a/src/burlap/oomdp/stochasticgames/agentactions/ObParamSGAgentAction.java
+++ b/src/burlap/oomdp/stochasticgames/agentactions/ObParamSGAgentAction.java
@@ -167,7 +167,7 @@ public abstract class ObParamSGAgentAction extends SGAgentAction {
 		 */
 		@Override
 		public String justActionString(){
-			StringBuffer buf = new StringBuffer();
+		    StringBuilder buf = new StringBuilder();
 			buf.append(action.actionName);
 			for(int i = 0; i < params.length; i++){
 				buf.append(" ").append(params[i]);
@@ -179,7 +179,7 @@ public abstract class ObParamSGAgentAction extends SGAgentAction {
 
 		@Override
 		public String toString(){
-			StringBuffer buf = new StringBuffer();
+		    StringBuilder buf = new StringBuilder();
 			buf.append(actingAgent).append(":");
 			buf.append(action.actionName);
 			for(int i = 0; i < params.length; i++){

--- a/src/burlap/oomdp/stochasticgames/common/VisualWorldObserver.java
+++ b/src/burlap/oomdp/stochasticgames/common/VisualWorldObserver.java
@@ -200,7 +200,7 @@ public class VisualWorldObserver extends JFrame implements WorldObserver {
 	
 	private void updatePropTextArea(State s){
 		
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		
 		List <PropositionalFunction> props = domain.getPropFunctions();
 		for(PropositionalFunction pf : props){

--- a/src/burlap/oomdp/stochasticgames/explorers/SGVisualExplorer.java
+++ b/src/burlap/oomdp/stochasticgames/explorers/SGVisualExplorer.java
@@ -386,7 +386,7 @@ public class SGVisualExplorer extends JFrame implements ShellObserver, WorldObse
 	
 	protected void updatePropTextArea(State s){
 		
-		StringBuffer buf = new StringBuffer();
+	    StringBuilder buf = new StringBuilder();
 		
 		List <PropositionalFunction> props = domain.getPropFunctions();
 		for(PropositionalFunction pf : props){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed