### PR TITLE
Fixed RandomPolicy constructor

### DIFF
--- a/src/burlap/behavior/policy/RandomPolicy.java
+++ b/src/burlap/behavior/policy/RandomPolicy.java
@@ -49,7 +49,7 @@ public class RandomPolicy extends Policy{
 	 * list for this policy.
 	 * @param acitons the actions to select between.
 	 */
-	public RandomPolicy(List<Action> acitons){
+	public RandomPolicy(List<Action> actions){
 		this.actions = new ArrayList<Action>(actions);
 	}
 


### PR DESCRIPTION
The input actions was misspelled causing the "actions" to reference "this.actions," which was being used to create a new array, resulting in a NullPointerException.