### PR TITLE
Fixing allJointActionsHelper for agents with different ActionTypes

### DIFF
--- a/src/main/java/burlap/mdp/stochasticgames/JointAction.java
+++ b/src/main/java/burlap/mdp/stochasticgames/JointAction.java
@@ -203,9 +203,9 @@ public class JointAction implements Action, Iterable<Action>{
 
 		List<Action> agentsChoices = individualActionChoices.get(i);
 		for(Action gsa : agentsChoices){
-			currentSelections.push(gsa);
+			currentSelections.addLast(gsa);
 			allJointActionsHelper(individualActionChoices, i+1, currentSelections, allJointActions);
-			currentSelections.pop();
+			currentSelections.remove(i);
 		}
 	}
 	


### PR DESCRIPTION
Fixing the allJointActionsHelper method when the agents may have different applicable actions in the same state.