### PR TITLE
Fixes an ArrayIndexOutOfBoundsException for block dude.

### DIFF
--- a/src/main/java/burlap/domain/singleagent/blockdude/BlockDudeModel.java
+++ b/src/main/java/burlap/domain/singleagent/blockdude/BlockDudeModel.java
@@ -138,7 +138,7 @@ public class BlockDudeModel implements FullStateModel {
 		int nx = ax+dir;
 		int ny = ay+1;
 
-		if(nx < 0 || nx > maxx){
+		if(nx < 0 || nx >= maxx){
 			return;
 		}
 
@@ -241,6 +241,10 @@ public class BlockDudeModel implements FullStateModel {
 
 
 		int nx = ax + dir;
+		
+		if (nx < 0 || nx >= maxx) {
+			return; // cannot drop block past the edge of the map
+		}
 
 		int heightAtNX = greatestHeightBelow(s, map, maxx, nx, ay+1);
 		if(heightAtNX > ay){


### PR DESCRIPTION
Fixes an ArrayIndexOutOfBoundsException when block dude is at the edge of a map facing the edge.