### PR TITLE
Correct the value of transitioning to a new state

### DIFF
--- a/src/main/java/burlap/domain/singleagent/gridworld/GridWorldRewardFunction.java
+++ b/src/main/java/burlap/domain/singleagent/gridworld/GridWorldRewardFunction.java
@@ -98,8 +98,8 @@ public class GridWorldRewardFunction implements RewardFunction {
 	@Override
 	public double reward(State s, Action a, State sprime) {
 
-		int x = ((GridWorldState)s).agent.x;
-		int y = ((GridWorldState)s).agent.y;
+		int x = ((GridWorldState)sprime).agent.x;
+		int y = ((GridWorldState)sprime).agent.y;
 		
 		if(x >= this.width || x < 0 || y >= this.height || y < 0){
 			throw new RuntimeException("GridWorld reward matrix is only defined for a " + this.width + "x" + 


### PR DESCRIPTION
This PR fixes the bug where the reward from transitioning from one state to another picks the wrong state to perform it's calculations. This is similar to what we are doing when calculating reward in the GoalBasedRF.class file