### PR TITLE
Updated BlockDudeModel.java to fix array index out of bounds

### DIFF
--- a/src/main/java/burlap/domain/singleagent/blockdude/BlockDudeModel.java
+++ b/src/main/java/burlap/domain/singleagent/blockdude/BlockDudeModel.java
@@ -138,7 +138,7 @@ public class BlockDudeModel implements FullStateModel {
 		int nx = ax+dir;
 		int ny = ay+1;
 
-		if(nx < 0 || nx > maxx){
+		if(nx < 0 || nx >= maxx){
 			return;
 		}
 


### PR DESCRIPTION
When BlockDude domain with level 1 or level 2 is run for value iteration, it's throwing array index out of bounds exception. After debugging, i figured out that in moveUp method we have missed the condition ">=" and instead have ">"